### PR TITLE
Support `else:` in conditional declarations

### DIFF
--- a/src/std/d/ast.d
+++ b/src/std/d/ast.d
@@ -1060,11 +1060,11 @@ final class ConditionalDeclaration : ASTNode
 public:
     override void accept(ASTVisitor visitor) const
     {
-        mixin (visitIfNotNull!(compileCondition, trueDeclarations, falseDeclaration));
+        mixin (visitIfNotNull!(compileCondition, trueDeclarations, falseDeclarations));
     }
     /** */ CompileCondition compileCondition;
     /** */ Declaration[] trueDeclarations;
-    /** */ Declaration falseDeclaration;
+    /** */ Declaration[] falseDeclarations;
     mixin OpEquals;
 }
 

--- a/src/std/d/formatter.d
+++ b/src/std/d/formatter.d
@@ -779,35 +779,61 @@ class Formatter(Sink)
         putAttrs(attrs);
         format(decl.compileCondition);
 
-        assert(decl.trueDeclarations.length <= 1); // spec bug?
+        assert(decl.trueDeclarations.length > 0);
 
-        if (decl.trueDeclarations.length)
+        if (decl.trueDeclarations.length == 1)
         {
             if (isEmptyDeclaration(decl.trueDeclarations[0]))
             {
                 space();
                 put("{}");
             }
+            else if (decl.trueDeclarations[0].conditionalDeclaration !is null)
+            {
+                format(decl.trueDeclarations[0].conditionalDeclaration);
+            }
             else
+            {
                 maybeIndent(decl.trueDeclarations[0]);
+            }
+        }
+        else
+        {
+            put(":");
+            foreach (d; decl.trueDeclarations)
+                format(d);
+
+            assert(decl.falseDeclarations.length == 0);
+            return;
         }
 
-        if (decl.falseDeclaration)
+        if (decl.falseDeclarations.length > 0)
         {
             newThing(What.else_);
-            sink.put("else ");
+            sink.put("else");
 
-            if (isEmptyDeclaration(decl.falseDeclaration))
+            if (decl.falseDeclarations.length == 1)
             {
-                space();
-                put("{}");
-                return;
+                if (isEmptyDeclaration(decl.falseDeclarations[0]))
+                {
+                    space();
+                    put("{}");
+                }
+                else if (decl.falseDeclarations[0].conditionalDeclaration !is null)
+                {
+                    format(decl.falseDeclarations[0]);
+                }
+                else
+                {
+                    maybeIndent(decl.falseDeclarations[0]);
+                }
             }
-
-            if (decl.falseDeclaration.conditionalDeclaration)
-                format(decl.falseDeclaration);
             else
-                maybeIndent(decl.falseDeclaration);
+            {
+                put(":");
+                foreach (d; decl.falseDeclarations)
+                    format(d);
+            }
         }
     }
 

--- a/src/std/d/parser.d
+++ b/src/std/d/parser.d
@@ -1493,7 +1493,7 @@ class Parser
      * $(GRAMMAR $(RULEDEF conditionalDeclaration):
      *       $(RULE compileCondition) $(RULE declaration)
      *     | $(RULE compileCondition) $(LITERAL ':') $(RULE declaration)+
-     *     | $(RULE compileCondition) $(RULE declaration) $(LITERAL 'else') $(RULE declaration)
+     *     | $(RULE compileCondition) $(RULE declaration) $(LITERAL 'else') ($(RULE declaration) | $(LITERAL ':') $(RULE declaration)+)
      *     ;)
      */
     ConditionalDeclaration parseConditionalDeclaration()
@@ -1532,15 +1532,29 @@ class Parser
         node.trueDeclarations = ownArray(trueDeclarations);
 
         if (currentIs(tok!"else"))
-            advance();
-        else
-            return node;
-
-        if ((node.falseDeclaration = parseDeclaration(suppressMessages > 0)) is null)
         {
-            deallocate(node);
-            return null;
+            advance();
+            if (currentIs(tok!":"))
+            {
+                advance();
+
+                while (moreTokens() && !currentIs(tok!"}"))
+                {
+                    auto decl = parseDeclaration(suppressMessages > 0);
+                    mixin (nullCheck!"decl");
+                    node.falseDeclarations ~= decl;
+                }
+                node.falseDeclarations = ownArray(node.falseDeclarations);
+            }
+            else
+            {
+                auto elseDec = parseDeclaration(suppressMessages > 0);
+                mixin (nullCheck!"elseDec");
+                node.falseDeclarations ~= elseDec;
+                node.falseDeclarations = ownArray(node.falseDeclarations);
+            }
         }
+
         return node;
     }
 

--- a/test/pass_files/declarations.d
+++ b/test/pass_files/declarations.d
@@ -29,6 +29,12 @@ debug = identifier;
 version(AArch64) enum x = 100;
 version = coverage;
 
+debug {
+	version(A) {} else:
+	int a;
+}
+else:
+
 static if (true):
 mixin ("int a;");
 mixin something;


### PR DESCRIPTION
```d
version (A) {
	void foo() {}
} else:
void bar() {}
void baz() {}
```
Else branches in conditional declarations can have multiple declarations. Libdparse cannot parse `else:`, and the AST node of `ConditionalDeclaration` is defined as
```d
...
Declaration[] trueDeclarations;
Declaration falseDeclaration;
...
```

So I fixed the parser, and changed that node definition to:
```d
...
Declaration[] trueDeclarations;
Declaration[] falseDeclarations;
...
```
