### PR TITLE
Misc Formatter Fixes

### DIFF
--- a/src/std/d/formatter.d
+++ b/src/std/d/formatter.d
@@ -462,6 +462,7 @@ class Formatter(Sink)
             }
             if (deprecated_) format(deprecated_);
             if (atAttribute) format(atAttribute);
+            if (linkageAttribute) format(linkageAttribute);
         }
     }
 

--- a/src/std/d/formatter.d
+++ b/src/std/d/formatter.d
@@ -718,7 +718,6 @@ class Formatter(Sink)
 
         if (decl.baseClassList)
         {
-            put(": ");
             format(decl.baseClassList);
         }
 
@@ -1813,7 +1812,6 @@ class Formatter(Sink)
             }
             if (baseClassList)
             {
-                put(": ");
                 format(baseClassList);
             }
 

--- a/src/std/d/formatter.d
+++ b/src/std/d/formatter.d
@@ -2633,6 +2633,7 @@ class Formatter(Sink)
         /**
         AtAttribute atAttribute;
         Deprecated deprecated_;
+        LinkageAttribute linkageAttribute;
         Token token;
         **/
 
@@ -2640,6 +2641,7 @@ class Formatter(Sink)
         {
             if (atAttribute) format(atAttribute);
             else if (deprecated_) format(deprecated_);
+            else if (linkageAttribute) format(linkageAttribute);
             else format(token);
         }
     }

--- a/src/std/d/formatter.d
+++ b/src/std/d/formatter.d
@@ -1462,6 +1462,9 @@ class Formatter(Sink)
         putComment(decl.comment);
         putAttrs(attrs);
 
+        foreach (sc; decl.storageClasses)
+            format(sc);
+
         if (decl.returnType)
             format(decl.returnType);
 


### PR DESCRIPTION
Only one colon for base class lists
Print out linkageAttributes in more places