### PR TITLE
Handling of .line, .column and .location in std.d.parse.simpleParse()

### DIFF
--- a/src/std/d/ast.d
+++ b/src/std/d/ast.d
@@ -2528,6 +2528,8 @@ public:
     }
     /** */ FunctionBody functionBody;
     /** */ size_t location;
+    /** */ size_t line;
+    /** */ size_t column;
     /** */ string comment;
     mixin OpEquals;
 }
@@ -2542,6 +2544,8 @@ public:
     }
     /** */ FunctionBody functionBody;
     /** */ size_t location;
+    /** */ size_t line;
+    /** */ size_t column;
     /** */ string comment;
     mixin OpEquals;
 }

--- a/src/std/d/parser.d
+++ b/src/std/d/parser.d
@@ -7246,15 +7246,26 @@ protected:
     template simpleParse(NodeType, parts ...)
     {
         static if (__traits(hasMember, NodeType, "comment"))
-            enum simpleParse = "auto node = allocate!" ~ NodeType.stringof ~ ";\n"
-                ~ "node.comment = comment;\n"
-                ~ "comment = null;\n"
-                ~ simpleParseItems!(parts)
-                ~ "\nreturn node;\n";
-        else
-            enum simpleParse = "auto node = allocate!" ~ NodeType.stringof ~ ";\n"
-                ~ simpleParseItems!(parts)
-                ~ "\nreturn node;\n";
+            enum nodeComm = "node.comment = comment;\n"
+                        ~ "comment = null;\n";
+        else enum nodeComm = "";
+                        
+        static if (__traits(hasMember, NodeType, "line"))
+            enum nodeLine = "node.line = current().line;\n";
+        else enum nodeLine = "";
+            
+        static if (__traits(hasMember, NodeType, "column"))
+            enum nodeColumn = "node.column = current().column;\n";
+        else enum nodeColumn = "";
+        
+        static if (__traits(hasMember, NodeType, "location"))
+            enum nodeLoc = "node.location = current().index;\n";
+        else enum nodeLoc = "";
+        
+        enum simpleParse = "auto node = allocate!" ~ NodeType.stringof ~ ";\n"
+                        ~ nodeComm ~ nodeLine ~ nodeColumn ~ nodeLoc 
+                        ~ simpleParseItems!(parts)
+                        ~ "\nreturn node;\n";                        
     }
 
     template simpleParseItems(items ...)


### PR DESCRIPTION
This modifications are proposed because of  #41 

- it doesn't break any previous usage of the AST nodes  _StaticConstructor_ and _StaticDestructor_ because the previous member _location_ is not replaced (even if useless since now line and col are more usable).
- notice that there was a doubt about _how-to_ because it would also be possible to implement the feature specifically for the two items instead of globally, in simpleParse().