### PR TITLE
Set the correct targetName and make targetType explicit, update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .dub
 docs.json
 __dummy.html
-*.o
+*.[oa]
 *.obj
 test/coverage/*
 test/tester
+dub.selections.json

--- a/dub.json
+++ b/dub.json
@@ -1,5 +1,7 @@
 {
 	"name": "libdparse",
+	"targetName": "dparse",
+	"targetType": "library",
 	"description": "Library for lexing and parsing D source code",
 	"license": "BSL-1.0",
         "version": "0.2.1",


### PR DESCRIPTION
- dub output files `liblibdparse.a` -> Fixed via `targetName`;
- `targetType` makes the intended target explicit: else it is determined as an app if there's a `src/app.d`, as a library otherwise.
- Add relevant entry to .gitignore so that it plays nicely with submodules