### PR TITLE
Fix #70: Parse error on `else:` in ConditionalDeclaration

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -1151,11 +1151,14 @@ final class ConditionalDeclaration : ASTNode
 public:
     override void accept(ASTVisitor visitor) const
     {
-        mixin (visitIfNotNull!(compileCondition, trueDeclarations, falseDeclaration));
+        mixin (visitIfNotNull!(compileCondition, trueDeclarations, falseDeclarations));
     }
     /** */ CompileCondition compileCondition;
     /** */ Declaration[] trueDeclarations;
-    /** */ Declaration falseDeclaration;
+    /** */ Declaration[] falseDeclarations;
+    /** */
+    deprecated("Please use `falseDeclarations` (array) instead")
+    Declaration falseDeclaration;
     mixin OpEquals;
 }
 

--- a/test/pass_files/issue0070.d
+++ b/test/pass_files/issue0070.d
@@ -1,0 +1,13 @@
+version (Foo)
+{
+    version(D_Version2)
+    {
+        public import core.memory;
+    }
+    else:
+}
+
+version (Bar)
+    int foo ();
+else:
+    int foo(int);


### PR DESCRIPTION
Allow code such as `version (X) {} else:` as DMD does.
As a result, there can be multiple `falseDeclaration` in a `conditionalStatement`,
so the single member was deprecated in favor of an array.

Fix Hackerpilot/libdparse#70

Note: It makes libdparse inevitably triggers a few deprecation warnings.