### PR TITLE
set public the lexer messages, fix #109

### DIFF
--- a/src/dparse/lexer.d
+++ b/src/dparse/lexer.d
@@ -1770,7 +1770,7 @@ private pure nothrow @safe:
         bool isError;
     }
 
-    Message[] messages;
+    public Message[] messages;
     StringCache* cache;
     LexerConfig config;
     bool haveSSE42;


### PR DESCRIPTION
A callback is not possible without changing the attributes, at least this will allow to copy them.