### PR TITLE
parse segment register suffixes

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -749,6 +749,7 @@ public:
     /** */ ExpressionNode asmExp;
     /** */ IdentifierChain identifierChain;
     /** */ Register register;
+    /** */ ExpressionNode segmentOverrideSuffix;
     /** */ Token token;
     mixin OpEquals;
 }

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -584,6 +584,7 @@ class Parser
      *     | $(LITERAL FloatLiteral)
      *     | $(LITERAL StringLiteral)
      *     | $(RULE register)
+     *     | $(RULE register : AsmExp)
      *     | $(RULE identifierChain)
      *     | $(LITERAL '$')
      *     ;)
@@ -608,6 +609,11 @@ class Parser
             {
                 trace("Found register");
                 mixin (nullCheck!`(node.register = parseRegister())`);
+                if (current.type == tok!":")
+                {
+                    advance();
+                    mixin(parseNodeQ!(`node.segmentOverrideSuffix`, `AsmExp`));
+                }
             }
             else
                 mixin(parseNodeQ!(`node.identifierChain`, `IdentifierChain`));

--- a/test/pass_files/asm.d
+++ b/test/pass_files/asm.d
@@ -30,6 +30,9 @@ void doStuff()
 		mov RAX, -a;
 		mov RAX, +a;
 		mov RAX, offsetof a;
+		mov EAX, FS:4;
+		mov EAX, FS:CL;
+		push dword ptr FS:[0];
 		jge short L_largepositive;
 		lea EDX,[ECX][ECX*8];
 		in AL,6;


### PR DESCRIPTION
Because in the current state, segment register overrides are seen as errors.