### PR TITLE
Improve Postblit parsing and add location, line and column

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -2396,6 +2396,9 @@ public:
     }
     /** */ FunctionBody functionBody;
     /** */ MemberFunctionAttribute[] memberFunctionAttributes;
+    /** */ size_t location;
+    /** */ size_t line;
+    /** */ size_t column;
     mixin OpEquals;
 }
 

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -4290,6 +4290,9 @@ class Parser
     {
         mixin(traceEnterAndExit!(__FUNCTION__));
         auto node = allocator.make!Postblit;
+        node.line = current.line;
+        node.column = current.column;
+        node.location = current.index;
         expect(tok!"this");
         expect(tok!"(");
         expect(tok!"this");

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -4293,10 +4293,7 @@ class Parser
         node.line = current.line;
         node.column = current.column;
         node.location = current.index;
-        expect(tok!"this");
-        expect(tok!"(");
-        expect(tok!"this");
-        expect(tok!")");
+        index += 4;
         StackBuffer memberFunctionAttributes;
         while (currentIsMemberFunctionAttribute())
             if (!memberFunctionAttributes.put(parseMemberFunctionAttribute()))


### PR DESCRIPTION
By the way I have a question:

`ParsePostblit` has:
```D
        expect(tok!"this");
        expect(tok!"(");
        expect(tok!"this");
        expect(tok!")");
```

but the `ParsePostblit` caller does already the lookup:

```D
            if (startsWith(tok!"this", tok!"(", tok!"this", tok!")"))
                mixin(parseNodeQ!(`node.postblit`, `Postblit`));
```  

Could the 4 `expect` be replaced by `index += 4` ? A few branches could be avoided in this case.

