### PR TITLE
Added start/end index to import declaration

### DIFF
--- a/src/dparse/ast.d
+++ b/src/dparse/ast.d
@@ -1894,6 +1894,8 @@ public:
     }
     /** */ SingleImport[] singleImports;
     /** */ ImportBindings importBindings;
+    /** */ size_t startIndex;
+    /** */ size_t endIndex;
     mixin OpEquals;
 }
 

--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -3361,6 +3361,7 @@ class Parser
     ImportDeclaration parseImportDeclaration()
     {
         auto node = allocator.make!ImportDeclaration;
+        node.startIndex = current().index;
         mixin(tokenCheck!"import");
         SingleImport si = parseSingleImport();
         if (si is null)
@@ -3395,6 +3396,7 @@ class Parser
             }
             ownArray(node.singleImports, singleImports);
         }
+        node.endIndex = current().index + 1;
         mixin(tokenCheck!";");
         return node;
     }


### PR DESCRIPTION
Not really fixing any issue or anything but this is useful to have. Might also add this to every AST node actually. This is particularly useful for example in dscanner for the import listing to give definition ranges instead of just the names of the modules.