### PR TITLE
fix #106 - missing rule in IfCondition parser

### DIFF
--- a/test/pass_files/issue0106.d
+++ b/test/pass_files/issue0106.d
@@ -1,0 +1,3 @@
+void foo1(){if (const a = 0){}} 
+void foo2(){if (const shared a = 0){}}
+void foo3(){if (immutable shared a = 0){}}


### PR DESCRIPTION
see https://dlang.org/spec/statement.html#if-statement

it was `TypeCtors Identifier = Expression` that missed.