### PR TITLE
fix regression in parseIfStatement

### DIFF
--- a/src/dparse/parser.d
+++ b/src/dparse/parser.d
@@ -3258,8 +3258,9 @@ class Parser
             expect(tok!"=");
             mixin(parseNodeQ!(`node.expression`, `Expression`));
         }
-        else if (isTypeCtor(current.type))
+        else
         {
+            // consume for TypeCtors = identifier
             while (isTypeCtor(current.type))
             {
                 const prev = current.type;
@@ -3267,14 +3268,10 @@ class Parser
                 if (current.type == prev)
                     warn("redundant type constructor");
             }
-            const i = expect(tok!"identifier");
-            if (i !is null)
-                node.identifier = *i;
-            expect(tok!"=");
-            mixin(parseNodeQ!(`node.expression`, `Expression`));
-        }
-        else
-        {
+            // goes back for TypeCtor(Type) = identifier
+            if (currentIs(tok!"("))
+                index--;
+
             immutable b = setBookmark();
             immutable c = allocator.setCheckpoint();
             auto type = parseType();

--- a/test/fail_files/ifConditions.d
+++ b/test/fail_files/ifConditions.d
@@ -1,0 +1,6 @@
+void foo()
+{
+    if (auto const(Type)* data = call()){}
+    if (const const a = call()){}
+    if (auto auto a = call()){}
+}

--- a/test/pass_files/ifConditions.d
+++ b/test/pass_files/ifConditions.d
@@ -1,0 +1,8 @@
+void foo()
+{
+    if (const(Type)* data = call()){}
+    if (const a = call()){}
+    if (const shared a = call()){}
+    if (auto a = call()){}
+    if (immutable shared(Type) a = call()){}
+}


### PR DESCRIPTION
In #106 I broke 

```d
 if (TypeCtor(Type) ident = stuff){}
```

by allowing

```d
 if (TypeCtor ident = stuff){}
```

It's well tested now.

