### PR TITLE
Formatter: print FunctionLiteralExpression correctly

### DIFF
--- a/src/dparse/formatter.d
+++ b/src/dparse/formatter.d
@@ -1489,12 +1489,24 @@ class Formatter(Sink)
     void format(const FunctionLiteralExpression functionLiteralExpression)
     {
         debug(verbose) writeln("FunctionLiteralExpression");
+        /**
+        ExpressionNode assignExpression;
+        FunctionAttribute[] functionAttributes;
+        FunctionBody functionBody;
+        IdType functionOrDelegate;
+        MemberFunctionAttribute[] memberFunctionAttributes;
+        Parameters parameters;
+        Token identifier;
+        Type returnType;
+        **/
 
         with(functionLiteralExpression)
         {
             put(tokenRep(functionOrDelegate));
 
-            space();
+            if (returnType || parameters)
+                space();
+
             if (returnType) format(returnType);
             if (parameters) format(parameters);
 
@@ -1509,6 +1521,7 @@ class Formatter(Sink)
                 format(functionBody);
             else
             {
+                format(identifier);
                 put(" => ");
                 format(assignExpression);
             }


### PR DESCRIPTION
The identifier of the FunctionLiteralExpression doesn't get correctly printed with the formatter (and FWIW also not with `dscanner --ast`).

Previously:

```
In: map!(i => i)
Out: map!(  => i)
```

See also: https://github.com/Hackerpilot/libdparse/blob/master/src/dparse/parser.d#L3010

I couldn't find a place for tests of the formatter. A good test would be to parse, and dump a lot of D code with high coverage (e.g. parts of Phobos or Mir) - if afterwards all tests still pass, the formatter didn't totally screw up...